### PR TITLE
Fix for running with a Redis instance with no password

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const {
 	REDIS_HOST = 'localhost',
 	REDIS_PASSWORD,
 	REDIS_USE_TLS,
-	BULL_PREFIX,
-	PORT
+	BULL_PREFIX = 'bull',
+	PORT = 3000
 } = process.env;
 
 const redisConfig = {

--- a/index.js
+++ b/index.js
@@ -3,18 +3,27 @@ const Queue = require('bull');
 const express = require('express');
 const redis = require('redis');
 
+const {
+	REDIS_PORT = 6379,
+	REDIS_HOST = 'localhost',
+	REDIS_PASSWORD,
+	REDIS_USE_TLS,
+	BULL_PREFIX,
+	PORT
+} = process.env;
+
 const redisConfig = {
 	redis: {
-		port: process.env.REDIS_PORT,
-		host: process.env.REDIS_HOST,
-		password: process.env.REDIS_PASSWORD,
-		tls: process.env.REDIS_USE_TLS === 'true',
+		port: REDIS_PORT,
+		host: REDIS_HOST,
+		...(REDIS_PASSWORD && { password: REDIS_PASSWORD }),
+		tls: REDIS_USE_TLS === 'true',
 	},
 };
 
 const client = redis.createClient(redisConfig.redis);
-const prefix = process.env.BULL_PREFIX;
-const port = process.env.PORT;
+const prefix = BULL_PREFIX;
+const port = PORT;
 
 client.KEYS(`${prefix}:*`, (err, keys) => {
 	const uniqKeys = new Set(keys.map(key => key.replace(/^.+?:(.+?):.+?$/, '$1')));


### PR DESCRIPTION
The default empty string `REDIS_PASSWORD=""` is always passed to the Redis server when connecting resulting in the following error when Redis is configured without a password (Redis version 6.0.7):

> ReplyError: ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?

This pull request conditionally passes the `password` option which fixes this problem.