### PR TITLE
Add BASE_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ see "Example with docker-compose" section for example with env parameters
 * `REDIS_USE_TLS` - enable TLS true or false (false by default)
 * `REDIS_PASSWORD` - password to connect to redis (no password by default)
 * `BULL_PREFIX` - prefix to your bull queue name (bull by default)
+* `BASE_PATH` - basePath for bull board, e.g. '/bull-board' ('/' by default)
 
 ### Example with docker-compose
 ```

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const {
 	REDIS_PASSWORD,
 	REDIS_USE_TLS,
 	BULL_PREFIX = 'bull',
-	PORT = 3000
+	PORT = 3000,
+	BASE_PATH = '/'
 } = process.env;
 
 const redisConfig = {
@@ -24,6 +25,7 @@ const redisConfig = {
 const client = redis.createClient(redisConfig.redis);
 const prefix = BULL_PREFIX;
 const port = PORT;
+const basePath = BASE_PATH;
 
 client.KEYS(`${prefix}:*`, (err, keys) => {
 	const uniqKeys = new Set(keys.map(key => key.replace(/^.+?:(.+?):.+?$/, '$1')));
@@ -34,7 +36,7 @@ client.KEYS(`${prefix}:*`, (err, keys) => {
 
 const app = express();
 
-app.use('/', router);
+app.use(`${basePath}`, router);
 app.listen(port, () => {
-	console.log(`bull-board listening on port ${port}!`);
+	console.log(`bull-board listening on port ${port} on basePath "${basePath}"!`);
 });


### PR DESCRIPTION
This PR adds a BASE_PATH environment variable which is useful if you want to run bull-board under a different path than root "/", e.g. "/bull-board".

This is my first PR for another project, so let me know if the change makes sense to you or if you want to have something changed. 

I'm also not 100% sure if this is everything we need to change to run it under a different basePath, but I just tested it and it seems to do the trick.

Thank you!