### PR TITLE
fix: configure bullmq with prefix when present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,11 @@ client.KEYS(`${config.BULL_PREFIX}:*`, (err, keys) => {
 	const queueList = Array.from(uniqKeys).sort().map(
 		(item) => {
 			if (config.BULL_VERSION === 'BULLMQ') {
-				return new BullMQAdapter(new bullmq.Queue(item, {connection: redisConfig.redis}));
+				const options = { connection: redisConfig.redis };
+				if (config.BULL_PREFIX) {
+					options.prefix = config.BULL_PREFIX;
+				}
+				return new BullMQAdapter(new bullmq.Queue(item, options));
 			}
 
 			return new BullAdapter(new Queue(item, redisConfig));


### PR DESCRIPTION
## Scenario

When running bull-board with a Redis in cluster mode and configuring `BULL_PREFIX`, bull-board would not load. The request to fetch queues would fail with `CROSSSLOT Keys in request don't hash to the same slot`.

The same issue can happen when prefix is not configured for Queue and Worker instances in the application code.

## Solution

Explicitly pass `prefix` based on the `BULL_PREFIX` configuration paramater when instantiating `bullmq.Queue`.